### PR TITLE
Re-render with a conda config workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,10 @@ install:
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
-      conda config --set show_channel_urls true
       conda update --yes conda
       conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
+      conda config --set show_channel_urls true
       
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,9 +49,9 @@ install:
     - cmd: set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
     - cmd: conda config --add channels conda-forge
+    - cmd: conda config --set show_channel_urls true
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
     # Workaround for Python 3.4 and x64 bug in latest conda-build.


### PR DESCRIPTION
Fixes https://github.com/conda-forge/symengine-feedstock/issues/1

Re-renders using @ocefpaf's PR ( https://github.com/conda-forge/conda-smithy/pull/199 ), which has a workaround for `conda config` issues with channels being removed given certain combinations of `conda config` calls. See issues ( https://github.com/Anaconda-Platform/support/issues/45 ) ( https://github.com/conda/conda/issues/2669 ) for the history, workaround, and fix. This should be fixed in `conda` soon. However, this provides a workaround to get this working for now.

If this passes, please merge.
